### PR TITLE
v15.0.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "unicodedata2" %}
-{% set version = "14.0.0" %}
-{% set sha256 = "41f7df0043f4450e84203d907a56cdd2a0a0541a9eebbaba48576b01e0b61684" %}
+{% set version = "15.0.0" %}
+{% set sha256 = "ed6c683f7b0a58cd11824b440d8ad24b22904ab3f63fc851bbcd7e518fa68f2d" %}
 
 package:
   name: {{ name|lower }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -41,6 +41,7 @@ about:
   summary: unicodedata backport/updates to python 3 and python 2.
   description: unicodedata backport/updates to python 3 and python 2.
   dev_url: https://github.com/mikekap/unicodedata2
+  doc_url: https://docs.python.org/3/library/unicodedata.html
 
 extra:
   recipe-maintainers:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -34,13 +34,13 @@ test:
     - pip
 
 about:
-  home: https://github.com/mikekap/unicodedata2
+  home: https://github.com/fonttools/unicodedata2
   license: Apache-2.0
   license_family: Apache
   license_file: LICENSE
   summary: unicodedata backport/updates to python 3 and python 2.
   description: unicodedata backport/updates to python 3 and python 2.
-  dev_url: https://github.com/mikekap/unicodedata2
+  dev_url: https://github.com/fonttools/unicodedata2
   doc_url: https://docs.python.org/3/library/unicodedata.html
 
 extra:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -28,6 +28,10 @@ requirements:
 test:
   imports:
     - unicodedata2
+  commands:
+    - pip check
+  requires:
+    - pip
 
 about:
   home: https://github.com/mikekap/unicodedata2


### PR DESCRIPTION
# unicodedata2 v15.0.0

upstream: https://github.com/fonttools/unicodedata2/tree/15.0.0?
license: https://github.com/fonttools/unicodedata2/blob/15.0.0/LICENSE
`setup.py`: https://github.com/fonttools/unicodedata2/blob/15.0.0/setup.py

## Changes
- Update version and SHA
- Add `pip check`
- Update about section

## Notes
- This adds python 3.11 support