### PR TITLE
unicodedata2 15.1.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "unicodedata2" %}
-{% set version = "15.0.0" %}
-{% set sha256 = "ed6c683f7b0a58cd11824b440d8ad24b22904ab3f63fc851bbcd7e518fa68f2d" %}
+{% set version = "15.1.0" %}
+{% set sha256 = "cb30f189ad66482f8529a45da71b2a8841e9bd2bb376cc2933003a4a55a07648" %}
 
 package:
   name: {{ name|lower }}
@@ -12,7 +12,7 @@ source:
 
 build:
   number: 0
-  script: {{ PYTHON }} -m pip install . -vv
+  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
 
 requirements:
   build:


### PR DESCRIPTION
unicodedata2 15.1.0

**Destination channel:** defaults

Needed as a dependency for `fonttools 4.49.0`, in order to resolve [CVE-2023-45139](https://anaconda.atlassian.net/browse/CVE-745)

### Links

- [PKG-4463](https://anaconda.atlassian.net/browse/PKG-4463) 
- [Upstream repository](https://github.com/fonttools/unicodedata2)
- Relevant PRs:
  - https://github.com/AnacondaRecipes/fonttools-feedstock/pull/16

### Explanation of changes:

- added script line
- bumped version number and updated SHA


[PKG-4463]: https://anaconda.atlassian.net/browse/PKG-4463?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ