### PR TITLE
unicodedata2 16.0.0 

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,21 +1,21 @@
 {% set name = "unicodedata2" %}
-{% set version = "15.1.0" %}
-{% set sha256 = "cb30f189ad66482f8529a45da71b2a8841e9bd2bb376cc2933003a4a55a07648" %}
+{% set version = "16.0.0" %}
 
 package:
   name: {{ name|lower }}
   version: {{ version }}
 
 source:
-  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: {{ sha256 }}
+  url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: 05488d6592b59cd78b61ec37d38725416b2df62efafa6a0d63a631b27aa474fc
 
 build:
-  number: 1
+  number: 0
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
 
 requirements:
   build:
+    - {{ stdlib('c') }}
     - {{ compiler('c') }}
   host:
     - python
@@ -26,12 +26,16 @@ requirements:
     - python
 
 test:
+  source_files:
+    - tests
   imports:
     - unicodedata2
   commands:
     - pip check
+    - pytest -v tests
   requires:
     - pip
+    - pytest
 
 about:
   home: https://github.com/fonttools/unicodedata2


### PR DESCRIPTION
unicodedata2 16.0.0 

**Destination channel:** Defaults

### Links

- [PKG-10330]
- dev_url:        https://github.com/fonttools/unicodedata2/tree/16.0.0
- conda_forge:    https://github.com/conda-forge/unicodedata2-feedstock
- pypi:           https://pypi.org/project/unicodedata2/16.0.0
- pypi inspector: https://inspector.pypi.io/project/unicodedata2/16.0.0

### Explanation of changes:

- new version number


[PKG-10330]: https://anaconda.atlassian.net/browse/PKG-10330?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ