### PR TITLE
unicodedata2 17.0.1 

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -2,7 +2,7 @@
 {% set version = "17.0.1" %}
 
 package:
-  name: {{ name|lower }}
+  name: {{ name }}
   version: {{ version }}
 
 source:
@@ -26,6 +26,9 @@ requirements:
     - python
 
 test:
+  requires:
+    - pip
+    - pytest
   source_files:
     - tests
   imports:
@@ -33,9 +36,6 @@ test:
   commands:
     - pip check
     - pytest -v tests
-  requires:
-    - pip
-    - pytest
 
 about:
   home: https://github.com/fonttools/unicodedata2

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "unicodedata2" %}
-{% set version = "16.0.0" %}
+{% set version = "17.0.1" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: 05488d6592b59cd78b61ec37d38725416b2df62efafa6a0d63a631b27aa474fc
+  sha256: d79943d153f5f6bfbe3f55a5ec611985184bda37fcedb3ecc75322d82ae6ad3b
 
 build:
   number: 0


### PR DESCRIPTION
unicodedata2 17.0.1 

**Destination channel:** Defaults

### Links

- [PKG-15807]
- dev_url:        https://github.com/fonttools/unicodedata2/tree/17.0.1
- conda_forge:    https://github.com/conda-forge/unicodedata2-feedstock
- pypi:           https://pypi.org/project/unicodedata2/17.0.1
- pypi inspector: https://inspector.pypi.io/project/unicodedata2/17.0.1

### Explanation of changes:

- new version number


[PKG-15807]: https://anaconda.atlassian.net/browse/PKG-15807?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ